### PR TITLE
Fix Token not refreshed before expiry causes 403 errors / unavailable…

### DIFF
--- a/custom_components/ms365_teams/integration/coordinator_integration.py
+++ b/custom_components/ms365_teams/integration/coordinator_integration.py
@@ -145,6 +145,10 @@ class MS365SensorCoordinator(DataUpdateCoordinator):
         data = []
         self._data[entity_key] = {}
         extra_attributes = {}
+
+        _LOGGER.debug("Refreshing MS365 token before chat update.")
+        await self.hass.async_add_executor_job(self._account.connection.refresh_token)
+        
         chats = await self.hass.async_add_executor_job(
             ft.partial(self._account.teams().get_my_chats, limit=20)
         )


### PR DESCRIPTION
… sensors

Fix for issue #68

This fixes a bug where the integration fails to refresh the Microsoft Graph access token before it expires. As a result, the API request to /me/chats occasionally returns a 403 Forbidden with “No authorization information present.”

The fix ensures refresh_token() is called before the Teams chat update request, avoiding token expiry mid-request.

Tested:
 - Patched locally in Home Assistant.
 - Confirmed stable operation across multiple update intervals with no 403s.
